### PR TITLE
Allow the use of iconv() instead of mb_convert_encoding()

### DIFF
--- a/src/Captioning/Format/SubstationalphaFile.php
+++ b/src/Captioning/Format/SubstationalphaFile.php
@@ -13,7 +13,7 @@ class SubstationalphaFile extends File
     protected $events;
     protected $comments;
 
-    public function __construct($_filename = null, $_encoding = null)
+    public function __construct($_filename = null, $_encoding = null, $_useIconv = false)
     {
         $this->headers = array(
             'Title'                => '<untitled>',
@@ -65,7 +65,7 @@ class SubstationalphaFile extends File
 
         $this->comments = array();
 
-        parent::__construct($_filename, $_encoding);
+        parent::__construct($_filename, $_encoding, $_useIconv);
     }
 
     public function setHeader($_name, $_value)


### PR DESCRIPTION
Hello again,

Implemented the use of iconv() instead of mb_convert_encoding() when dealing with encoding conversion. This is set up as a flag in constructor, with false as default.

Thanks
