### PR TITLE
Can use BOM when saving file

### DIFF
--- a/src/Captioning/File.php
+++ b/src/Captioning/File.php
@@ -424,6 +424,7 @@ abstract class File implements FileInterface
      * Saves the file
      *
      * @param string $filename
+     * @param bool $writeBOM
      */
     public function save($filename = null, $writeBOM = false)
     {


### PR DESCRIPTION
Since using utf-8, allow the use of Byte Mark Order (BOM) when saving file.
A bool can be passed to save() method that prepends "\xef\xbb\xbf" to file_content when saving file.

Thanks
