### PR TITLE
Parse Subrip files without trailing newline

### DIFF
--- a/src/Captioning/Format/SubripFile.php
+++ b/src/Captioning/Format/SubripFile.php
@@ -15,15 +15,14 @@ class SubripFile extends File
         [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}         # Start time.
         [ ]-->[ ]                               # Time delimiter.
         [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}         # End time.
-        \1                                      # Line end.
-        (?:[\S ]+\1)+                           # Subtitle text.
+        (?:\1[\S ]+)+                           # Subtitle text.
                        ### Other subtitles ###
         (?:
-            \1(?<=\r\n|\r|\n)[\d]+\1
+            \1\1(?<=\r\n|\r|\n)[\d]+\1
             [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}
             [ ]-->[ ]
             [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}
-            \1(?:[\S ]+\1)+
+            (?:\1[\S ]+)+
         )*
         \1?
         $/xu'

--- a/tests/Captioning/Format/SubripFileTest.php
+++ b/tests/Captioning/Format/SubripFileTest.php
@@ -39,6 +39,15 @@ class SubripFileTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testIfAFileWithoutTrailingNewlineIsParsedProperly()
+    {
+        $filename = __DIR__.'/../../Fixtures/example-nonewline.srt';
+        $file = new SubripFile($filename);
+
+        $this->assertEquals(3, $file->getCuesCount());
+        $this->assertEquals('Would you like to get a coffee?', $file->getCue(2)->getText());
+    }
+
     public function testIfWeGetTheFirstCue()
     {
         // example file from W3C spec

--- a/tests/Fixtures/example-nonewline.srt
+++ b/tests/Fixtures/example-nonewline.srt
@@ -1,0 +1,12 @@
+1
+00:00:00,000 --> 00:00:20,000
+Hi, my name is Fred,
+nice to meet you.
+
+2
+00:00:21,500 --> 00:00:22,500
+Hi, I'm Bill.
+
+3
+00:00:23,000 --> 00:00:25,000
+Would you like to get a coffee?


### PR DESCRIPTION
Some Subrip files do not end with a trailing newline. This patch will allow to parse such files.