### PR TITLE
Clear data from previuos loads

### DIFF
--- a/src/Captioning/File.php
+++ b/src/Captioning/File.php
@@ -162,6 +162,8 @@ abstract class File implements FileInterface
 
     public function loadFromString($_str)
     {
+        // Clear cues from previous runs
+        $this->cues = array();
         $this->fileContent = $_str;
 
         $this->encode();


### PR DESCRIPTION
If you perform `loadFromFile` or `loadFromString` more that once on instance you will get content of all previously loaded files in last.