### PR TITLE
Loose SRT validation start

### DIFF
--- a/src/Captioning/File.php
+++ b/src/Captioning/File.php
@@ -229,16 +229,19 @@ abstract class File implements FileInterface
     /**
      * Add a cue
      *
-     * @param mixed $_mixed An cue instance or a string representing the text
+     * @param mixed  $_mixed An cue instance or a string representing the text
      * @param string $_start A timecode
-     * @param string $_stop A timecode
+     * @param string $_stop  A timecode
+     *
+     * @return $this
+     * @throws \Exception
      */
     public function addCue($_mixed, $_start = null, $_stop = null)
     {
         $fileFormat = self::getFormat($this);
 
         // if $_mixed is a Cue
-        if (is_subclass_of($_mixed, __NAMESPACE__.'\Cue')) {
+        if (is_object($_mixed) && class_exists(get_class($_mixed)) && class_exists(__NAMESPACE__.'\Cue') && is_subclass_of($_mixed, __NAMESPACE__.'\Cue')) {
             $cueFormat = Cue::getFormat($_mixed);
             if ($cueFormat !== $fileFormat) {
                 throw new \Exception("Can't add a $cueFormat cue in a $fileFormat file.");

--- a/src/Captioning/Format/SubripFile.php
+++ b/src/Captioning/Format/SubripFile.php
@@ -6,42 +6,67 @@ use Captioning\File;
 
 class SubripFile extends File
 {
-    const PATTERN =
-        '/^
-                       ### First subtitle ###
-        [\p{C}]{0,3}                            # BOM
-        [\d]+                                   # Subtitle order.
-        ((?:\r\n|\r|\n))                        # Line end.
-        [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}         # Start time.
-        [ ]-->[ ]                               # Time delimiter.
-        [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}         # End time.
-        (?:\1[\S ]+)+                           # Subtitle text.
-                       ### Other subtitles ###
-        (?:
-            \1\1(?<=\r\n|\r|\n)[\d]+\1
-            [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}
-            [ ]-->[ ]
-            [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}
-            (?:\1[\S ]+)+
-        )*
-        \1?
-        $/xu'
+    const PATTERN_STRICT =
+    '/^
+                   ### First subtitle ###
+    [\p{C}]{0,3}                            # BOM
+    [\d]+                                   # Subtitle order.
+    ((?:\r\n|\r|\n))                        # Line end.
+    [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}         # Start time.
+    [ ]-->[ ]                               # Time delimiter.
+    [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}         # End time.
+    (?:\1[\S ]+)+                           # Subtitle text.
+                   ### Other subtitles ###
+    (?:
+        \1\1(?<=\r\n|\r|\n)[\d]+\1
+        [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}
+        [ ]-->[ ]
+        [\d]{2}:[\d]{2}:[\d]{2},[\d]{3}
+        (?:\1[\S ]+)+
+    )*
+    \1?
+    $/xu'
     ;
 
-    private $defaultOptions = array('_stripTags' => false, '_stripBasic' => false, '_replacements' => false);
+    const PATTERN_LOOSE =
+    '/^
+                   ### First subtitle ###
+    [\p{C}]{0,3}                                    # BOM
+    [\d]+                                           # Subtitle order.
+    ((?:\r\n|\r|\n))                                # Line end.
+    [\d]{1,2}:[\d]{1,2}:[\d]{1,2}(?:,[\d]{1,3})?    # Start time. Milliseconds or leading zeroes not required.
+    [ ]-->[ ]                                       # Time delimiter.
+    [\d]{1,2}:[\d]{1,2}:[\d]{1,2}(?:,[\d]{1,3})?    # End time. Milliseconds or leading zeroes not required.
+    (?:\1[\S ]+)+                                   # Subtitle text.
+                   ### Other subtitles ###
+    (?:
+        \1\1(?<=\r\n|\r|\n)[\d]+\1
+        [\d]{1,2}:[\d]{1,2}:[\d]{1,2}(?:,[\d]{1,3})?
+        [ ]-->[ ]
+        [\d]{1,2}:[\d]{1,2}:[\d]{1,2}(?:,[\d]{1,3})?
+        (?:\1[\S ]+)+
+    )*
+    \1?
+    \s* # Allow trailing whitespace
+    $/xu'
+    ;
+
+    private $defaultOptions = array('_stripTags' => false, '_stripBasic' => false, '_replacements' => false, '_requireStrictFileFormat' => true);
 
     private $options = array();
 
-    public function __construct($_filename = null, $_encoding = null, $_useIconv = false)
+    public function __construct($_filename = null, $_encoding = null, $_useIconv = false, $_requireStrictFileFormat = true)
     {
-        parent::__construct($_filename, $_encoding, $_useIconv);
         $this->options = $this->defaultOptions;
+        $this->options['_requireStrictFileFormat'] = $_requireStrictFileFormat;
+
+        parent::__construct($_filename, $_encoding, $_useIconv);
     }
 
     public function parse()
     {
         $matches = array();
-        $res = preg_match(self::PATTERN, $this->fileContent, $matches);
+        $res = preg_match(($this->options['_requireStrictFileFormat'] ? self::PATTERN_STRICT : self::PATTERN_LOOSE), $this->fileContent, $matches);
 
         if ($res === false || $res === 0) {
             throw new \Exception($this->filename.' is not a proper .srt file.');
@@ -61,10 +86,18 @@ class SubripFile extends File
             $subtitleTimeStart = $timeline[0];
             $subtitleTimeEnd = $timeline[1];
 
+            if (!$this->options['_requireStrictFileFormat']) {
+                $subtitleTimeStart = $this->cleanUpTimecode($subtitleTimeStart);
+                $subtitleTimeEnd = $this->cleanUpTimecode($subtitleTimeEnd);
+            }
+
             if (
                 $subtitle[0] != $subtitleOrder++ ||
-                !$this->validateTimelines($subtitleTime, $subtitleTimeStart, true) ||
-                !$this->validateTimelines($subtitleTimeStart, $subtitleTimeEnd)
+                !$this->validateTimelines($subtitleTimeStart, $subtitleTimeEnd, !$this->options['_requireStrictFileFormat']) ||
+                (
+                    $this->options['_requireStrictFileFormat'] && // Allow overlapping timecodes when not in "strict mode"
+                    !$this->validateTimelines($subtitleTime, $subtitleTimeStart, true)
+                )
             ) {
                 throw new \Exception($this->filename.' is not a proper .srt file.');
             }
@@ -178,5 +211,24 @@ class SubripFile extends File
         }
 
         return $startTimeline < $endTimeline;
+    }
+
+    /**
+     * Add milliseconds and leading zeroes if they are missing
+     *
+     * @param $timecode
+     *
+     * @return mixed
+     */
+    private function cleanUpTimecode($timecode)
+    {
+        strpos($timecode, ',') ?: $timecode .= ',000';
+
+        $patternNoLeadingZeroes = '/(?:(?<=\:)|^)\d(?=(:|,))/';
+
+        return preg_replace_callback($patternNoLeadingZeroes, function($matches)
+        {
+            return sprintf('%02d', $matches[0]);
+        }, $timecode);
     }
 }

--- a/src/Captioning/Format/SubripFile.php
+++ b/src/Captioning/Format/SubripFile.php
@@ -99,7 +99,7 @@ class SubripFile extends File
                     !$this->validateTimelines($subtitleTime, $subtitleTimeStart, true)
                 )
             ) {
-                throw new \Exception($this->filename.' is not a proper .srt file.');
+                throw new \Exception($this->filename . " failed timeline validation. ({$subtitleTimeStart} --> {$subtitleTimeEnd})");
             }
 
             $subtitleTime = $subtitleTimeEnd;


### PR DESCRIPTION
I referenced this in issue https://github.com/captioning/captioning/issues/22#issuecomment-200285424

**Things I allow in my "loose validation mode":**

* Milliseconds aren't required for timecodes
* Trailing whitespace at the end of the file is allowed
* Equal begin and end timecodes are allowed by default in loose validation mode
* Overlapping timecodes are allowed
* Timecodes without leading zeroes in any of the time units are allowed

**Things I encountered, but didn't allow in my implementation:**

* Leading whiteline in the subtitle text
* Empty subtitle text
* Missing subtitle index/order number