### PR TITLE
(Work in progress) Retool .srt processing for error recovery, reporting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
         "psr-0": {
             "Captioning": "src/"
         }
+    },
+    "scripts": {
+      "test": "phpunit"
     }
 }


### PR DESCRIPTION
(I want to test & fix this a little more but am putting up a PR before I get distracted. Not yet tested against the unit tests, just against my data set from Wikimedia Commons where I now get a lot more files through the conversion.)

Parses incoming Subrip .srt files line by line instead of with a giant
regex; should be more robust and report syntax errors more cleanly, as
well as avoiding a class of segfault failures with the regex engine
in some versions of PHP.

Syntax oddities now passed through:
- more than 2 lines used as separator
- whitespace after cue index
- whitespace after timestamp
- initial index of 0 (if using loose mode)

Line number is now reported when syntax goes unexpectedly off the
rails, making it much easier to track down what was wrong.

Not fully tested yet. Likely to have bugs.
