### PR TITLE
Add 'test' script command to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
         "psr-0": {
             "Captioning": "src/"
         }
+    },
+    "scripts": {
+      "test": "phpunit"
     }
 }


### PR DESCRIPTION
Allows running phpunit via 'composer test' on local checkout
after 'composer install' even if phpunit is not globally
installed on the machine.