### PR TITLE
Subrip: Added support for emty lines after timestamp.

### DIFF
--- a/src/Captioning/Format/SubripFile.php
+++ b/src/Captioning/Format/SubripFile.php
@@ -72,7 +72,6 @@ class SubripFile extends File
 
         $state = 'order';
         foreach ($lines as $lineNumber => $line) {
-        
             switch ($state) {
             case 'order':
                 if (!preg_match(self::PATTERN_ORDER, $line)) {
@@ -113,12 +112,14 @@ class SubripFile extends File
                     throw new \Exception($this->filename.' is not a proper .srt file. (Ending time invalid: '.$subtitleTimeEnd.' at line '.$lineNumber.')');
                 }
                 $subtitleText = array();
+                $subtitleTextRaw = '';
                 $state = 'text';
                 break;
 
             case 'text':
                 $subtitleText[] = $line;
-                if ($lineNumber === count($lines) - 1 || ($line === '' && $lines[$lineNumber+1] !== '')) {
+                $subtitleTextRaw .= $line;
+                if (($lineNumber === count($lines) - 1) || ($line === '' && $lines[$lineNumber+1] !== '' && $subtitleTextRaw != '')) {
                   $state = 'end';
                   // Fall through...
                 } else {

--- a/tests/Captioning/Format/SubripFileTest.php
+++ b/tests/Captioning/Format/SubripFileTest.php
@@ -110,4 +110,17 @@ class SubripFileTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\Exception', $filename.' is not a proper .srt file.');
         new SubripFile($filename);
     }
+
+    public function testFileWithEmptyLinesAfterTime()
+    {
+        $filename = __DIR__.'/../../Fixtures/example-empty-lines-after-time.srt';
+        $file = new SubripFile($filename);
+
+        // cues
+        $this->assertEquals(5, $file->getCuesCount());
+        $this->assertEquals('00:00:26,000', $file->getCue(3)->getStart());
+        $this->assertEquals('00:00:27,000', $file->getCue(3)->getStop());
+        $this->assertEquals("\n\n\nThis is empty line after time", $file->getCue(3)->getText());
+    }
+
 }

--- a/tests/Fixtures/example-empty-lines-after-time.srt
+++ b/tests/Fixtures/example-empty-lines-after-time.srt
@@ -1,0 +1,26 @@
+1
+00:00:00,000 --> 00:00:20,000
+Hi, my name is Fred,
+nice to meet you.
+
+2
+00:00:21,500 --> 00:00:22,500
+Hi, I'm Bill.
+
+3
+00:00:23,000 --> 00:00:25,000
+Would you like to get a coffee?
+
+4
+00:00:26,000 --> 00:00:27,000
+
+
+
+This is empty line after time
+
+5
+00:00:28,000 --> 00:00:29,000
+
+
+THE END
+


### PR DESCRIPTION
We sometimes (10%) see SRT files, which contain empty lines after timestamp. VLC can play them without any issue.

What might be considered to think about - I haven't found any official subrip specification, so I don't know if this is allowed. There might be considered option to update this patch with strict check and allow empty lines after timestamp only when strict is false.