### PR TITLE
Replace print_r by implode for Exception message

### DIFF
--- a/src/Captioning/Format/WebvttFile.php
+++ b/src/Captioning/Format/WebvttFile.php
@@ -119,7 +119,7 @@ class WebvttFile extends File
         } while (($line = $this->getNextValueFromArray($fileContentArray)) !== false);
 
         if (count($parsing_errors) > 0) {
-            throw new \Exception('The following errors were found while parsing the file:'."\n".print_r($parsing_errors, true));
+            throw new \Exception('The following errors were found while parsing the file:'."\n".implode("\n", $parsing_errors));
         }
 
         return $this;

--- a/tests/Captioning/Format/WebvttFileTest.php
+++ b/tests/Captioning/Format/WebvttFileTest.php
@@ -130,7 +130,7 @@ class WebvttFileTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(
             'Exception',
-            'The following errors were found while parsing the file:'."\n".print_r($errors, true)
+            'The following errors were found while parsing the file:'."\n".implode("\n", $errors)
         );
         $webVttFile = $this->getWebvttFile($this->pathToVtts.$vtt);
         $webVttFile->parse();


### PR DESCRIPTION
Exception raised by the WebvttFile class display an ugly array(...) instead of a beautiful error message. This PR fix this issue.