### PR TITLE
Improve PHP 8.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 .idea/
+composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "captioning/captioning",
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.4.*@dev"
+        "phpunit/phpunit": "^6.0|^9.0"
     },
     "authors": [
         {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
-         bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Captioning Test Suite">
-            <directory>tests/Captioning/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/Captioning/</directory>
-        </whitelist>
-    </filter>
+         bootstrap="vendor/autoload.php"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/Captioning/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Captioning Test Suite">
+      <directory>tests/Captioning/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Captioning/Cue.php
+++ b/src/Captioning/Cue.php
@@ -338,13 +338,13 @@ abstract class Cue implements CueInterface
      */
     public static function ms2tc($ms, $_separator = '.', $isHoursPaddingEnabled = true)
     {
-        $tc_ms = round((($ms / 1000) - intval($ms / 1000)) * 1000);
+        $tc_ms = round((($ms / 1000) - floor($ms / 1000)) * 1000);
         $x = $ms / 1000;
-        $tc_s = intval($x % 60);
+        $tc_s = floor((int)$x % 60);
         $x /= 60;
-        $tc_m = intval($x % 60);
+        $tc_m = floor((int)$x % 60);
         $x /= 60;
-        $tc_h = intval($x % 24);
+        $tc_h = floor((int)$x % 24);
 
         if ($isHoursPaddingEnabled) {
             $timecode = str_pad($tc_h, 2, '0', STR_PAD_LEFT).':';

--- a/tests/Captioning/ConverterTest.php
+++ b/tests/Captioning/ConverterTest.php
@@ -5,8 +5,9 @@ namespace Captioning;
 use Captioning\Format\SubripFile;
 use Captioning\Format\WebvttFile;
 use Captioning\Format\SubstationalphaFile;
+use PHPUnit\Framework\TestCase;
 
-class ConverterTest extends \PHPUnit_Framework_TestCase
+class ConverterTest extends TestCase
 {
     public function testSubrip2WebvttConversion()
     {
@@ -110,13 +111,12 @@ Dialogue: 0,0:01:12.50,0:01:32.50,Default,,0000,0000,0000,,OK, let's go.
         $this->assertEquals($content, $file->convertTo('substationalpha')->build()->getFileContent());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConverterException()
     {
-        $file = new SubripFile();
+        $this->expectException(\InvalidArgumentException::class);
 
+        $file = new SubripFile();
         $file->convertTo('foor');
+
     }
 }

--- a/tests/Captioning/Format/JsonFileTest.php
+++ b/tests/Captioning/Format/JsonFileTest.php
@@ -2,7 +2,9 @@
 
 namespace Captioning\Format;
 
-class JsonFileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class JsonFileTest extends TestCase
 {
     public function testIfAFileIsParsedProperly()
     {

--- a/tests/Captioning/Format/SBVFileTest.php
+++ b/tests/Captioning/Format/SBVFileTest.php
@@ -2,7 +2,9 @@
 
 namespace Captioning\Format;
 
-class SBVFileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SBVFileTest extends TestCase
 {
     public function testIfAFileIsParsedProperly()
     {

--- a/tests/Captioning/Format/SubripFileTest.php
+++ b/tests/Captioning/Format/SubripFileTest.php
@@ -2,7 +2,10 @@
 
 namespace Captioning\Format;
 
-class SubripFileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use Captioning\Format\SubripFile;
+
+class SubripFileTest extends TestCase
 {
     public function testAddingCuesBothWays()
     {
@@ -93,13 +96,14 @@ class SubripFileTest extends \PHPUnit_Framework_TestCase
     {
         $filename = __DIR__ . '/../../Fixtures/Subrip/passed-with-same-end-in-prev-and-start-next-cue.srt';
         $file = new SubripFile($filename);
-        $this->assertInstanceOf('Captioning\Format\SubripFile', $file);
+        $this->assertInstanceOf(SubripFile::class, $file);
     }
 
     public function testDoesNotAllowSameStartAndEndTime()
     {
         $filename = __DIR__ . '/../../Fixtures/Subrip/failed-equal-start-and-end-time-in-last-queue.srt';
-        $this->setExpectedException('\Exception', $filename.' is not a proper .srt file.');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($filename.' is not a proper .srt file.');
         new SubripFile($filename);
     }
 
@@ -107,7 +111,8 @@ class SubripFileTest extends \PHPUnit_Framework_TestCase
     public function testDoesNotAllowSameOrderIndex()
     {
         $filename = __DIR__ . '/../../Fixtures/Subrip/failed-equal-subtitle-order-number.srt';
-        $this->setExpectedException('\Exception', $filename.' is not a proper .srt file.');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($filename.' is not a proper .srt file.');
         new SubripFile($filename);
     }
 }

--- a/tests/Captioning/Format/WebvttFileTest.php
+++ b/tests/Captioning/Format/WebvttFileTest.php
@@ -2,18 +2,11 @@
 
 namespace Captioning\Format;
 
-class WebvttFileTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class WebvttFileTest extends TestCase
 {
-    /** @var string */
-    private $pathToVtts;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $ds = DIRECTORY_SEPARATOR;
-        $this->pathToVtts = __DIR__.$ds.'..'.$ds.'..'.$ds.'Fixtures'.$ds.'Webvtt'.$ds;
-    }
+    const PATH_TO_VTTTS = __DIR__.'/../../Fixtures/Webvtt/';
 
     /**
      * @return array
@@ -40,7 +33,7 @@ class WebvttFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParse($vtt)
     {
-        $webVttFile = $this->getWebvttFile($this->pathToVtts.$vtt);
+        $webVttFile = $this->getWebvttFile(self::PATH_TO_VTTTS.$vtt);
         $this->assertSame($webVttFile, $webVttFile->parse());
     }
 
@@ -129,24 +122,24 @@ class WebvttFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseException($vtt, array $errors)
     {
-        $this->setExpectedException(
-            'Exception',
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(
             'The following errors were found while parsing the file:'."\n".implode("\n", $errors)
         );
-        $webVttFile = $this->getWebvttFile($this->pathToVtts.$vtt);
+        $webVttFile = $this->getWebvttFile(self::PATH_TO_VTTTS.$vtt);
         $webVttFile->parse();
     }
 
     public function testRegionsEmpty()
     {
-        $webVttFile = $this->getWebvttFile($this->pathToVtts.'1.3-non-normative_other-features_1.vtt');
+        $webVttFile = $this->getWebvttFile(self::PATH_TO_VTTTS.'1.3-non-normative_other-features_1.vtt');
 
         $this->assertNull($webVttFile->getRegion(0));
     }
 
     public function testRegions()
     {
-        $webVttFile = $this->getWebvttFile($this->pathToVtts.'1.3-non-normative_other-features_4.vtt');
+        $webVttFile = $this->getWebvttFile(self::PATH_TO_VTTTS.'1.3-non-normative_other-features_4.vtt');
         $region = new WebvttRegion('fred', '40%', '3', '0%,100%', '10%,90%', 'up');
 
         $this->assertEquals($region, $webVttFile->getRegion(0));


### PR DESCRIPTION
Hey,

using a package with php8.1 got a lot of deprecated messages
> Implicit conversion from float <float_number> to int loses precision

also to work with PHP 8.1 was necessary to reconfigure the test system, and drop PHP 5.3-5.6 so it sounds like a BC so we will need to publish a new major version to not brake existing projects which uses this package =)